### PR TITLE
Update amplify yml file (expo web)

### DIFF
--- a/amplify-explicit.yml
+++ b/amplify-explicit.yml
@@ -3,7 +3,7 @@ frontend:
   phases:
     preBuild:
       commands:
-        - npm install --quiet --global expo-cli
+        - yarn global add expo-cli
         - >
           if [ -f yarn.lock ]; then
             yarn


### PR DESCRIPTION
With 
- npm install --quiet --global expo-cli
Amplify throws an error when npm is installing expo-cli globally
Replaced with:
- yarn global add expo-cli
works properly